### PR TITLE
Allow channel to be set/overridden, and allow attachments arrayto be added via msg

### DIFF
--- a/slackpost.html
+++ b/slackpost.html
@@ -16,59 +16,58 @@
 -->
 
 <script type="text/x-red" data-template-name="slack">
-    <br/>
     <div class="form-row">
         <label for="node-input-channelURL"><i class="fa fa-slack"></i> WebHook URL</label>
-        <input type="text" id="node-input-channelURL" placeholder="channelURL">
+        <input type="text" id="node-input-channelURL" placeholder="channelURL" style=" vertical-align: top;">
     </div>
 
-    <br/>
     <div class="form-row">
         <label for="node-input-username"><i class="fa fa-user"></i> Posting UserName</label>
-        <input type="text" id="node-input-username" placeholder="username">
+        <input type="text" id="node-input-username" placeholder="username" style=" vertical-align: top;">
     </div>
 
-    <br/>
     <div class="form-row">
         <label for="node-input-emojiIcon"><i class="fa fa-smile-o"></i> Emoji Icon</label>
-        <input type="text" id="node-input-emojiIcon" placeholder=":emojiIcon:">
+        <input type="text" id="node-input-emojiIcon" placeholder=":emojiIcon:" style=" vertical-align: top;">
     </div>
 
-    <br/>
+    <div class="form-row">
+        <label for="node-input-channel"><i class="fa fa-random"></i> Channel</label>
+        <input type="text" id="node-input-channel" placeholder="optional channel override">
+    </div>
+
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
 </script>
 
-
-<!-- Next, some simple help text is provided for the node.                   -->
 <script type="text/x-red" data-help-name="slack">
-   <p>Sends the <b>msg.payload</b> to Slack</p>
+   <p>Sends the <b>msg.payload</b> to Slack.</p>
    <p>Simple way to post to a Slack channel.</p>
+   <p>You can optionally override the destination channel if required - either in the edit dialogue or by setting <b>msg.channel</b>.</p>
+   <p>You can also create <a href="https://api.slack.com/docs/attachments" target="_new">Slack attachments</a> by adding a <b>msg.attachments</b> property that must be an array.</p>
 </script>
 
-<!-- Finally, the node type is registered along with all of its properties   -->
-<!-- The example below shows a small subset of the properties that can be set-->
 <script type="text/javascript">
     RED.nodes.registerType('slack',{
-        category: 'output',      // the palette category
-        defaults: {             // defines the editable properties of the node
-            name: {value:""},   //  along with default values.
+        category: 'output',
+        defaults: {
+            name: {value:""},
             channelURL: {value:"", required:true},
-            username: {value:""},   //  along with default values.
-            emojiIcon: {value:""}   //  along with default values.
+            username: {value:""},
+            emojiIcon: {value:""},
+            channel: {value:""}
         },
         color:"#4C9689",
         icon: "hash.png",
         align: "right",
-        inputs:1,               // set the number of inputs - only 0 or 1
-        outputs:0,              // set the number of outputs - 0 to n
-        // set the icon (held in icons dir below where you save the node)
-        label: function() {     // sets the default label contents
+        inputs:1,
+        outputs:0,
+        label: function() {
             return this.name||"slack";
         },
-        labelStyle: function() { // sets the class to apply to the label
+        labelStyle: function() {
             return this.name?"node_label_italic":"";
         }
     });

--- a/slackpost.html
+++ b/slackpost.html
@@ -51,7 +51,7 @@
 
 <script type="text/javascript">
     RED.nodes.registerType('slack',{
-        category: 'output',
+        category: 'social',
         defaults: {
             name: {value:""},
             channelURL: {value:"", required:true},

--- a/slackpost.js
+++ b/slackpost.js
@@ -15,16 +15,11 @@
  * limitations under the License.
  **/
 
-// If you use this as a template, update the copyright with your own name.
-
-
-
 module.exports = function(RED) {
     "use strict";
     var request = require('request');
 
     function slackOut(n) {
-        // Create a RED node
         RED.nodes.createNode(this,n);
 
         this.channelURL = n.channelURL;
@@ -32,17 +27,19 @@ module.exports = function(RED) {
         this.emojiIcon = n.emojiIcon || "";
         var node = this;
 
-        // respond to inputs....
         this.on('input', function (msg) {
             var channelURL = node.channelURL || msg.channelURL;
             var username = node.username || msg.username;
             var emojiIcon = node.emojiIcon || msg.emojiIcon;
+            var channel = node.channel || msg.channel;
 
             var data = {
                 "text": msg.payload,
                 "username": username,
                 "icon_emoji": emojiIcon
             };
+            if (channel) { data.channel = channel; }
+            if (msg.attachments) { data.attachments = msg.attachments; }
 
             try {
                 request({
@@ -52,16 +49,9 @@ module.exports = function(RED) {
                 });
             }
             catch (err) {
-                node.log(err);
+                node.log(err,msg);
             }
-
-
         });
     }
-
-    // Register the node by name. This must be called before overriding any of the
-    // Node functions.
     RED.nodes.registerType("slack", slackOut);
-
 };
-


### PR DESCRIPTION
Hi, great node - nice and simple and "just works".  It would be nice to also be able to set the channel (optionally), and also to allow the addition of so-called attachments. This PR attempts to do that. Rather than mess up the simple UI, attachments can only be added via msg.attachments prior to the node. - but this should be no hardship for anyone who needs this capability.

Thoughts ?

(Also moved it to the "social" category as it fits better alongside things like email, twitter, irc than simple led flashers etc.)
