### PR TITLE
Use node-red node.error to output errors instead of passing to slack-client. 

### DIFF
--- a/slackpost.js
+++ b/slackpost.js
@@ -27,13 +27,13 @@ module.exports = function(RED) {
             connecting = true;
             slackBotGlobal[token].login();
         } else {
-//            console.log("connected");  
-        }       
+//            console.log("connected");
+        }
     }
 
     function slackLogOut(token){
         if(slackBotGlobal[token] && slackBotGlobal[token].connected === true) {
-            connecting = false;            
+            connecting = false;
             var dis = slackBotGlobal[token].disconnect();
             slackBotGlobal[token].removeAllListeners();
             slackBotGlobal = {};
@@ -42,45 +42,45 @@ module.exports = function(RED) {
 
     function slackBotIn(n) {
         RED.nodes.createNode(this,n);
-        
+
         this.channel = n.channel || "";
         this.apiToken = n.apiToken;
         var node = this;
-                         
+
         var Slack = require('slack-client');
-        
+
         var token = this.apiToken;
         var autoReconnect = true;
         var autoMark = true;
-     
-        var slack = {};                  
+
+        var slack = {};
         if(slackBotGlobal && slackBotGlobal[token]) {
-//            console.log("IN: old slack session");            
-            slack = slackBotGlobal[token];            
+//            console.log("IN: old slack session");
+            slack = slackBotGlobal[token];
         } else {
-//            console.log("IN: new slack session"); 
+//            console.log("IN: new slack session");
             slack = new Slack(token, autoReconnect, autoMark);
-            slackBotGlobal[token] = slack;            
+            slackBotGlobal[token] = slack;
         }
 
         slack.on('message', function(message) {
-            var msg = { 
+            var msg = {
                 payload: message.text
             };
-            
+
             var slackChannel = slack.getChannelGroupOrDMByID(message.channel);
             var fromUser = slack.getUserByID(message.user);
 
             if(!fromUser) {
-                fromUser = { 
+                fromUser = {
                     name: ""
                 };
             }
-            
+
             if(node.channel === "" || slackChannel.name === node.channel) {
                 passMsg();
             }
-            
+
             function passMsg() {
                 msg.slackObj = {
                     "id": message.id,
@@ -90,69 +90,69 @@ module.exports = function(RED) {
                     "channel": message.channel,
                     "fromUser": fromUser.name
                 };
-                
-                node.send(msg);                
+
+                node.send(msg);
             }
 
         });
-           
+
         slack.on('error', function (error) {
-            this.error('Error: %s', error); 
+            node.error('Error: %s', error);
         });
-        
+
         slackLogin(token);
         setTimeout(function() {
             slackLogin(token);
-        }, 10000);    
-     
+        }, 10000);
+
         this.on('close', function() {
             slackLogOut(token);
-        });  
-        
+        });
+
     };
     RED.nodes.registerType("Slack Bot In", slackBotIn);
 
-    
+
     function slackBotOut(n) {
         RED.nodes.createNode(this,n);
-        
+
         this.apiToken = n.apiToken;
-        this.channel = n.channel || "";        
+        this.channel = n.channel || "";
         var node = this;
-    
+
         var Slack = require('slack-client');
-        
+
         var token = this.apiToken;
         var autoReconnect = true;
         var autoMark = true;
-    
-        var slack = {};                  
+
+        var slack = {};
         if(slackBotGlobal && slackBotGlobal[token]) {
 //            console.log("OUT: using an old slack session");
-            slack = slackBotGlobal[token];            
-        } else {  
+            slack = slackBotGlobal[token];
+        } else {
 //            console.log("OUT: new slack session");
             slack = new Slack(token, autoReconnect, autoMark);
-            slackBotGlobal[token] = slack;            
-        }     
-           
-        this.on('input', function (msg) { 
+            slackBotGlobal[token] = slack;
+        }
+
+        this.on('input', function (msg) {
             var channel = node.channel || msg.channel || "";
 
             var slackChannel = "";
             var slackObj = msg.slackObj;
-            
+
             if(channel !== "") {
-                slackChannel = slack.getChannelGroupOrDMByName(channel);                 
+                slackChannel = slack.getChannelGroupOrDMByName(channel);
             } else {
-                slackChannel = slack.getChannelGroupOrDMByID(slackObj.channel);                        
+                slackChannel = slack.getChannelGroupOrDMByID(slackObj.channel);
             }
-    
+
             if((slackChannel.is_member && slackChannel.is_member === false) || slackChannel.is_im === false) {
-                node.warn("Slack bot is not a member of this Channel");                
+                node.warn("Slack bot is not a member of this Channel");
                 return false;
-            }       
-                        
+            }
+
             try {
                 slackChannel.send(msg.payload);
             }
@@ -162,15 +162,15 @@ module.exports = function(RED) {
         });
 
         slack.on('error', function (error) {
-            this.error('Error: %s', error); 
+            node.error('Error: %s', error);
         });
-     
+
         this.on('close', function() {
             slackLogOut(token);
-        });          
+        });
     }
     RED.nodes.registerType("Slack Bot Out", slackBotOut);
-    
+
 
     function slackOut(n) {
         RED.nodes.createNode(this,n);

--- a/slackpost.js
+++ b/slackpost.js
@@ -97,7 +97,7 @@ module.exports = function(RED) {
         });
 
         slack.on('error', function (error) {
-            node.error('Error: %s', error);
+            node.error('Error: ' + error);
         });
 
         slackLogin(token);
@@ -162,7 +162,7 @@ module.exports = function(RED) {
         });
 
         slack.on('error', function (error) {
-            node.error('Error: %s', error);
+            node.error('Error: ' + error);
         });
 
         this.on('close', function() {


### PR DESCRIPTION
Lines 100 and 165 use this.error to manage errors. Depending on the deployment scenario this causes an error, referring to slack-client rather than node. A better solution is to simply use node.error("string") to manage this output (to fit with node-reds loging system - http://nodered.org/docs/writing-functions.html) this will output an error to the debug console.

Here is a trace error in our system:

```
14 Sep 17:57:22 - TypeError: Object #<Client> has no method 'error'
at Client.<anonymous> (/home/ubuntu/front-node-red/node-red-contrib/node_modules/node-red-contrib-slack/slackpost.js:100:18)
at Client.emit (events.js:117:20)
at Client._onLogin (/home/ubuntu/front-node-red/node-red-contrib/node_modules/node-red-contrib-slack/node_modules/slack-client/src/client.js:74:14)
at /home/ubuntu/front-node-red/node-red-contrib/node_modules/node-red-contrib-slack/node_modules/slack-client/src/client.js:2:59
at IncomingMessage.<anonymous> (/home/ubuntu/front-node-red/node-red-contrib/node_modules/node-red-contrib-slack/node_modules/slack-client/src/client.js:670:22)
at IncomingMessage.emit (events.js:117:20)
at _stream_readable.js:943:16
at process._tickCallback (node.js:419:13)
```

To replicate simply deploy an unconfigured and empty slack input node. 
