### PR TITLE
slackBotIn changed payload to message.getBody() added attachments

### DIFF
--- a/slackpost.js
+++ b/slackpost.js
@@ -80,7 +80,7 @@ module.exports = function(RED) {
 
         slack.on('message', function(message) {
             var msg = {
-                payload: message.text
+                payload: message.getBody()
             };
 
             var slackChannel = slack.getChannelGroupOrDMByID(message.channel);
@@ -103,7 +103,8 @@ module.exports = function(RED) {
                     "text": message.text,
                     "channelName": slackChannel.name,
                     "channel": message.channel,
-                    "fromUser": fromUser.name
+                    "fromUser": fromUser.name,
+                    "attachments" : message.attachments
                 };
 
                 node.send(msg);


### PR DESCRIPTION
Some bots (the IFTTT bot for example) send messages contained in the attachment part of the message and do not have a message.text element.  The slack-client library has a function getBody() that will pull the text body out of the attachment and combine with the message.text .  
Updated the slackBotIn function to set the payload to message.getBody()  rather than message.text
Added the attachment object to the slackObj
